### PR TITLE
Compatibility with Grails 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+grails-browser-detection
+========================
+The original version causes a VerifyError with grails 2.2.0.
+This fork solves this problem using a workaround.

--- a/application.properties
+++ b/application.properties
@@ -1,8 +1,8 @@
 #Grails Metadata file
 #Thu May 17 17:41:52 EEST 2012
-app.grails.version=2.0.3
+app.grails.version=2.2.0
 app.name=browser-detection
-plugins.hibernate=2.0.3
-plugins.release=2.0.2
+plugins.hibernate=2.2.0
+plugins.release=2.2.0
 plugins.svn=1.0.2
-plugins.tomcat=2.0.3
+plugins.tomcat=2.2.0

--- a/grails-app/taglib/org/geeks/browserdetection/BrowserTagLib.groovy
+++ b/grails-app/taglib/org/geeks/browserdetection/BrowserTagLib.groovy
@@ -23,25 +23,6 @@ class BrowserTagLib {
 
 	private static def CHOICE_STACK_NAME = "${this.name}_choiceStack"
 
-	private enum HierarchyLevelType {
-		ChoiceTag,
-		ConditionTag
-	}
-
-	/**
-	 * Describes a hierarchy level as the choice tag and
-	 * a condition tag
-	 */
-	private class HierarchyLevelHolder {
-		HierarchyLevelType levelType
-
-		/**
-		 * It makes sense only for the choice tag
-		 */
-		Closure otherwise
-		boolean successfulCondition
-	}
-
     def userAgentIdentService
 
 	def isMobile = { attrs, body ->
@@ -315,4 +296,23 @@ class BrowserTagLib {
 
 		stack.peek().otherwise = body
 	}
+}
+
+enum HierarchyLevelType {
+	ChoiceTag,
+	ConditionTag
+}
+
+/**
+ * Describes a hierarchy level as the choice tag and
+ * a condition tag
+ */
+class HierarchyLevelHolder {
+	HierarchyLevelType levelType
+
+	/**
+	 * It makes sense only for the choice tag
+	 */
+	Closure otherwise
+	boolean successfulCondition
 }


### PR DESCRIPTION
I have made some changes to make the plugin compatible with Grails 2.2.0.
I had the problem that I received a VerifyError in the taglib.
This was solved by simply moving two private inner classes outside of the taglib.
I am not sure if this is the best solution but at least it works.
Maybe have a look for yourself.
